### PR TITLE
Fix for "conditional comments" example

### DIFF
--- a/index.jade
+++ b/index.jade
@@ -218,7 +218,6 @@ html
         .row
           .span6
             textarea.size2.jade.
-              // if lt IE 8
               <!--[if lt IE 8]>
               <script src="/ie.js"></script>
               <![endif]-->

--- a/index.jade
+++ b/index.jade
@@ -219,7 +219,9 @@ html
           .span6
             textarea.size2.jade.
               // if lt IE 8
-                script(src='/ie.js')
+              <!--[if lt IE 8]>
+              <script src="/ie.js"></script>
+              <![endif]-->
           .span6.right
             textarea.size2.html(readonly=true)
       section#if


### PR DESCRIPTION
With (the current) version 1.7.0 of Jade, the special syntax for conditional comments mentioned here does no longer work for me. 

According to http://jade-lang.com/reference/comments/ "Jade does not have any special syntax for conditional comments."

Thus I have updated the example on how to achieve a conditional comment using the syntax described on the official homepage.
